### PR TITLE
drop use of tensorboard._vendor api

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM python:3.6
 WORKDIR /usr/src/app
 COPY . .
 RUN pip install tensorflow-gpu==2.1.0
+RUN pip install tensorflow-serving-api-gpu==2.1.0
 RUN pip install tensorboard==2.1.0
 RUN pip install websockets
 RUN pip install numpy

--- a/utils/analyzer.py
+++ b/utils/analyzer.py
@@ -5,10 +5,7 @@ import numpy as np
 from skimage import img_as_float32
 from skimage.transform import resize
 from subprocess import PIPE, Popen
-from tensorboard._vendor.tensorflow_serving.apis.predict_pb2 \
-  import PredictRequest  #TODO or not todo, find an alternative source of TF serving api
-from tensorboard._vendor.tensorflow_serving.apis.prediction_service_pb2_grpc \
-  import PredictionServiceStub
+from tensorflow_serving.apis import predict_pb2, prediction_service_pb2_grpc
 import tensorflow as tf
 
 
@@ -62,7 +59,7 @@ class VideoAnalyzer:
       self.input_name = 'input'
       self.output_name = 'probabilities'
     self.signature_name = model_signature_name
-    self.service_stub = PredictionServiceStub(
+    self.service_stub = prediction_service_pb2_grpc.PredictionServiceStub(
       insecure_channel(model_server_host))
 
     logging.debug('opening video frame pipe')
@@ -129,7 +126,7 @@ class VideoAnalyzer:
 
         frame = np.expand_dims(frame, axis=0)  # batchify single frame
 
-        request = PredictRequest()
+        request = predict_pb2.PredictRequest()
         request.model_spec.name = self.model_name
         request.model_spec.signature_name = self.signature_name
         request.inputs['input'].CopyFrom(
@@ -188,7 +185,7 @@ class VideoAnalyzer:
 
         frame = self._preprocess_frame_batch(frame)
 
-        request = PredictRequest()
+        request = predict_pb2.PredictRequest()
         request.model_spec.name = self.model_name
         request.model_spec.signature_name = self.signature_name
         request.inputs[self.input_name].CopyFrom(

--- a/utils/signalstateanalyzer.py
+++ b/utils/signalstateanalyzer.py
@@ -5,10 +5,7 @@ import numpy as np
 from skimage import img_as_float32
 from skimage.transform import resize
 from subprocess import PIPE, Popen
-from tensorboard._vendor.tensorflow_serving.apis.predict_pb2 \
-  import PredictRequest  #TODO or not todo, find an alternative source of TF serving api
-from tensorboard._vendor.tensorflow_serving.apis.prediction_service_pb2_grpc \
-  import PredictionServiceStub
+from tensorflow_serving.apis import predict_pb2, prediction_service_pb2_grpc
 import tensorflow as tf
 
 
@@ -58,7 +55,7 @@ class SignalVideoAnalyzer:
     max_msg_length = 100* 1024 * 1024
     options = [('grpc.max_message_length', max_msg_length), ('grpc.max_receive_message_length', max_msg_length)]
     channel = insecure_channel(model_server_host, options=options)
-    self.service_stub = PredictionServiceStub(channel)
+    self.service_stub = prediction_service_pb2_grpc.PredictionServiceStub(channel)
 
     logging.debug('opening video frame pipe')
 
@@ -124,7 +121,7 @@ class SignalVideoAnalyzer:
 
         frame = np.expand_dims(frame, axis=0)  # batchify single frame
 
-        request = PredictRequest()
+        request = predict_pb2.PredictRequest()
         request.model_spec.name = self.model_name
         request.model_spec.signature_name = self.signature_name
         request.inputs['input'].CopyFrom(
@@ -191,7 +188,7 @@ class SignalVideoAnalyzer:
           frame = frame[:, self.crop_y:self.crop_y + self.crop_height,
                   self.crop_x:self.crop_x + self.crop_width]
 
-        request = PredictRequest()
+        request = predict_pb2.PredictRequest()
         request.model_spec.name = self.model_name
         request.model_spec.signature_name = self.signature_name
         request.inputs['inputs'].CopyFrom(


### PR DESCRIPTION
Fixes issue #11 by dropping `tensorboard._vendor` in favor of `tensorflow_serving.apis`, which works in TF2.1+ instead of just TF<=2.1

* docker users will need to rebuild their image with `docker-compose build`
* non-docker GPU users of the `tensorflow-gpu` python package will need to install the `tensorflow-serving-api-gpu` python package that matches their desired version of tensorflow.
* non-docker GPU users of the `tensorflow` python package will need to install the `tensorflow-serving-api` python package that matches their desired version of tensorflow.

Special thanks to @daykac for helping to find and correct this